### PR TITLE
Custom Termination Signals in Vulnerability analysis

### DIFF
--- a/scripts/vulnerability_analysis.tcl
+++ b/scripts/vulnerability_analysis.tcl
@@ -97,14 +97,12 @@
 #                       'x' or 'z' on this signal is also interpreted as an
 #                       exception. This parameter MUST be provided by the user
 #                       and has no default value.
-# 'custom_termination_signal_one' : Path to some testbench signal that indicates
-#                       some other form of termination of the simulation. For 
-#                       example that the calculation would be restarted, de-
-#                       tected the fault, or self-corrected.
+# 'custom_termination_signal_list' : List of paths to some testbench signal that 
+#                       indicate some other form of termination of the simulation 
+#                       if asserted. For example that the calculation would be 
+#                       restarted, detected the fault, or self-corrected.
 #                       Note that an 'x' or 'z' on this signal is interpreted 
 #                       as an exception. Optional.
-# 'custom_termination_signal_two' : Same as above.
-# 'custom_termination_signal_three' : Same as above.
 # ------------------------------ Logging Settings -----------------------------
 # 'log_latent_errors' : Log the internal state comparison results if the
 #                       simulation terminates with id 1. For each mismatch,
@@ -446,14 +444,16 @@ set ::termination_signal_list [subst { \
   { 2 $::incorrect_termination_signal "Incorrect" } \
   { 0 $::correct_termination_signal   "Correct"   }}]
 
-if {[info exists ::custom_termination_signal_one]} \
-  { lappend ::termination_signal_list [ subst { 5 $::custom_termination_signal_one "Custom 1" }]}
-
-if {[info exists ::custom_termination_signal_two]} \
-  { lappend ::termination_signal_list [ subst { 6 $::custom_termination_signal_two "Custom 2" }]}
-
-if {[info exists ::custom_termination_signal_three]} \
-  { lappend ::termination_signal_list [ subst { 7 $::custom_termination_signal_three "Custom 3" }]}
+# Add custom termination types with higher id (lower priority)
+# Lowest ID that can be used is 5 (4 is Timeout)
+set custom_signal_counter 1
+foreach signal_var $::custom_termination_signal_list {
+    set signal_id [expr {4 + $custom_signal_counter}]
+    set signal_name "Custom $custom_signal_counter"
+    echo "\[Vulnerability Analysis\] Added custom termination signal $signal_var with Name $signal_name and ID $signal_id"
+    lappend ::termination_signal_list [subst { $signal_id $signal_var "$signal_name"}]
+    incr custom_signal_counter
+}
 
 # Report x and z as exception
 set ::termination_report_x_as_id 3

--- a/scripts/vulnerability_analysis.tcl
+++ b/scripts/vulnerability_analysis.tcl
@@ -97,6 +97,14 @@
 #                       'x' or 'z' on this signal is also interpreted as an
 #                       exception. This parameter MUST be provided by the user
 #                       and has no default value.
+# 'custom_termination_signal_one' : Path to some testbench signal that indicates
+#                       some other form of termination of the simulation. For 
+#                       example that the calculation would be restarted, de-
+#                       tected the fault, or self-corrected.
+#                       Note that an 'x' or 'z' on this signal is interpreted 
+#                       as an exception. Optional.
+# 'custom_termination_signal_two' : Same as above.
+# 'custom_termination_signal_three' : Same as above.
 # ------------------------------ Logging Settings -----------------------------
 # 'log_latent_errors' : Log the internal state comparison results if the
 #                       simulation terminates with id 1. For each mismatch,
@@ -434,9 +442,18 @@ set ::monitor_triggered 0
 
 # Configure the monitor settings for the golden model
 set ::termination_signal_list [subst { \
-  {3 $::exception_termination_signal "Exception" } \
-  {2 $::incorrect_termination_signal "Incorrect" } \
-  {0 $::correct_termination_signal   "Correct"   }}]
+  { 3 $::exception_termination_signal "Exception" } \
+  { 2 $::incorrect_termination_signal "Incorrect" } \
+  { 0 $::correct_termination_signal   "Correct"   }}]
+
+if {[info exists ::custom_termination_signal_one]} \
+  { lappend ::termination_signal_list [ subst { 5 $::custom_termination_signal_one "Custom 1" }]}
+
+if {[info exists ::custom_termination_signal_two]} \
+  { lappend ::termination_signal_list [ subst { 6 $::custom_termination_signal_two "Custom 2" }]}
+
+if {[info exists ::custom_termination_signal_three]} \
+  { lappend ::termination_signal_list [ subst { 7 $::custom_termination_signal_three "Custom 3" }]}
 
 # Report x and z as exception
 set ::termination_report_x_as_id 3


### PR DESCRIPTION
- Add some extra input parameters for vulnerability analysis that might be used with more complicated termination conditions like for example RedMulE. Instead of coming up with all possible cases just call them "custom".
- Adapted documentation accordingly