### PR TITLE
Improved variable passing between scripts.

### DIFF
--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -179,7 +179,7 @@ if {![info exists script_base_path]} { set script_base_path  "./" }
 # Timing settings
 if {![info exists inject_start_time]}            { set inject_start_time          100ns }
 if {![info exists inject_stop_time]}             { set inject_stop_time             0   }
-if {![info exists injection_clock]}              { set injection_clock          "clk"   }
+if {![info exists injection_clock]}              { set injection_clock             ""   }
 if {![info exists injection_clock_trigger]}      { set injection_clock_trigger      0   }
 if {![info exists fault_period]}                 { set fault_period                 0   }
 if {![info exists rand_initial_injection_phase]} { set rand_initial_injection_phase 0   }

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -49,8 +49,9 @@
 #                       triggered circuit is used as injection clock, it is
 #                       recommended to set the trigger to '0', so injected
 #                       flips can clearly be distinguished in the waveforms.
-# 'fault_period'      : Period of the fault injection in clock cycles of the
-#                       injection clock. Set to 0 for only a single flip.
+# 'fault_period'      : How many cycles of the `injection_clock` should pass
+#                       until the next fault injection is undertaken.
+#                       Set to 0 for only a single flip.
 # 'rand_initial_injection_phase' : Set the phase relative to the 'fault_period'
 #                       to a random initial value between 0 (inclusive) and
 #                       'fault_period' (exclusive). If multiple simulation

--- a/scripts/vulnerability_analysis.tcl
+++ b/scripts/vulnerability_analysis.tcl
@@ -554,7 +554,6 @@ if {$::latest_injection_time <= 0} {
 # The parameters for the fault injection script have to be set up by the user,
 # but some are explicitly set here:
 set ::seed [expr $::initial_seed + $::thread_id]
-if {![info exists injection_clock]} { set injection_clock "" }
 set inject_start_time $::earliest_injection_time
 set inject_stop_time $::latest_injection_time
 set forced_injection_times [list]

--- a/scripts/vulnerability_analysis.tcl
+++ b/scripts/vulnerability_analysis.tcl
@@ -165,6 +165,30 @@
 #                       'num_threads' threads that execute the workload.
 #                       If the workload is not parallellized and only executed
 #                       by a single thread, set 'num_threads' to 1 (default).
+# ----------------------------- Underlying Scripts -----------------------------
+# In addition, the following settings from inject_fault.tcl (documented there)
+# shoud / could be set:
+#
+# - Flip settings (mandatory):
+#   - 'allow_multi_bit_upset' 
+#   - 'use_bitwidth_as_weight' 
+#   - 'reg_to_sig_ratio'
+#   - 'signal_fault_duration' 
+#   - 'register_fault_duration' 
+#   - 'max_num_fault_inject' 
+#
+# - Statistics (not mandatory):
+#   - 'log_injections'
+#   - 'print_statistics'
+#
+# - Additional Checks (not mandatory):
+#   - 'check_core_output_modification' 
+#   - 'output_netlist'    
+#   - 'check_core_next_state_modification' 
+#   - 'next_state_netlist'
+#
+# - Additional Netlists (not mandatory):
+#   - 'assertion_disable_list'
 
 ##################################
 #  Set default parameter values  #
@@ -525,6 +549,8 @@ if {$::latest_injection_time <= 0} {
 # but some are explicitly set here:
 set ::seed [expr $::initial_seed + $::thread_id]
 set injection_clock ""
+set inject_start_time $::earliest_injection_time
+set inject_stop_time $::latest_injection_time
 set forced_injection_times [list]
 set forced_injection_signals [list]
 set ::include_forced_inj_in_stats 1

--- a/scripts/vulnerability_analysis.tcl
+++ b/scripts/vulnerability_analysis.tcl
@@ -175,7 +175,13 @@
 #   - 'reg_to_sig_ratio'
 #   - 'signal_fault_duration' 
 #   - 'register_fault_duration' 
-#   - 'max_num_fault_inject' 
+#   - 'max_num_fault_inject'
+# 
+# - Periodic Fault injection settings (not mandatory):
+#   - 'injection_clock'
+#   - 'injection_clock_trigger'
+#   - 'fault_period'
+#   - 'rand_initial_injection_phase'
 #
 # - Statistics (not mandatory):
 #   - 'log_injections'
@@ -548,7 +554,7 @@ if {$::latest_injection_time <= 0} {
 # The parameters for the fault injection script have to be set up by the user,
 # but some are explicitly set here:
 set ::seed [expr $::initial_seed + $::thread_id]
-set injection_clock ""
+if {![info exists injection_clock]} { set injection_clock "" }
 set inject_start_time $::earliest_injection_time
 set inject_stop_time $::latest_injection_time
 set forced_injection_times [list]


### PR DESCRIPTION
- Adds all signals to vulnerability analysis documentation that should be set and are currently just documented as "must be set by the user".
- Set start and stop time automatically as those are the only sensible values

I do not understand the existing documentation for `fault_period` and `rand_initial_injection_phase`.
Can these be used together with the vulnerability analysis and should therefore be mentioned? Or
are they excluded from the "must be set by the user" things?
Draft until answered.

Maybe we should do something similar for `vulnerability_net_analysis.tcl` also.