### PR TITLE
Correct recovery on combinatorial faults.

### DIFF
--- a/scripts/extract_nets.tcl
+++ b/scripts/extract_nets.tcl
@@ -44,23 +44,23 @@ if {![info exists verbosity]}        { set verbosity          2 }
 
 proc get_net_type {signal_name} {
   set sig_description [examine -describe $signal_name]
-  switch -glob -- $sig_description {
-  *Register* {
-    # ^ Matches Register, Signed Register, Integer Register
-    return "Register"
+  set type_string [string trim [string range $sig_description 1 [string wordend $sig_description 1]] " \n\r()\[\]{}:"]
+
+  # In case the first word is a predicate, we strip this word from the front and then try again
+  if { $type_string == "Verilog" || $type_string == "Signed" || $type_string == "Integer"} {
+
+      # Strip first word from text
+      set sig_description [string range $sig_description [string wordend $sig_description 1] [string length $sig_description]]
+
+      # Try exact same thing again
+      set type_string [string trim [string range $sig_description 1 [string wordend $sig_description 1]] " \n\r()\[\]{}:"]
+
+      # Capitalize Enum so it has the same format as other types
+      if { $type_string == "enum" } {
+        set type_string "Enum"
+      }
   }
-  *Net* {
-    # ^ Matches Net, Signed Net, Integer Net
-    return "Net"
-  }
-  *enum* {
-    # ^ Matches Verilog enum
-    return "Enum"
-  }
-  default {
-    return [string trim [string range $sig_description 1 [string wordend $sig_description 1]] " \n\r()\[\]{}"]
-  }
-}
+  return $type_string
 }
 
 proc get_net_array_length {signal_name} {

--- a/scripts/extract_nets.tcl
+++ b/scripts/extract_nets.tcl
@@ -47,7 +47,7 @@ proc get_net_type {signal_name} {
   set type_string [string trim [string range $sig_description 1 [string wordend $sig_description 1]] " \n\r()\[\]{}:"]
 
   # In case the first word is a predicate, we strip this word from the front and then try again
-  if { $type_string == "Verilog" || $type_string == "Signed" || $type_string == "Integer"} {
+  if { $type_string == "Verilog" || $type_string == "Signed"} {
 
       # Strip first word from text
       set sig_description [string range $sig_description [string wordend $sig_description 1] [string length $sig_description]]
@@ -127,7 +127,7 @@ proc extract_netlists {item_list {injection_save 0}} {
   set extract_list [list]
   foreach item $item_list {
     set item_type [get_net_type $item]
-    if {$item_type == "Register" || $item_type == "Net" || $item_type == "Enum"} {
+    if {$item_type == "Register" || $item_type == "Net" || $item_type == "Enum" || $item_type == "Integer"} {
       lappend extract_list $item
     } elseif { $item_type == "Array"} {
       set first_net "$item\[0\]"

--- a/scripts/extract_nets.tcl
+++ b/scripts/extract_nets.tcl
@@ -44,9 +44,23 @@ if {![info exists verbosity]}        { set verbosity          2 }
 
 proc get_net_type {signal_name} {
   set sig_description [examine -describe $signal_name]
-  set type_string [string trim [string range $sig_description 1 [string wordend $sig_description 1]] " \n\r()\[\]{}"]
-  if { $type_string == "Verilog" } { set type_string "Enum"}
-  return $type_string
+  switch -glob -- $sig_description {
+  *Register* {
+    # ^ Matches Register, Signed Register, Integer Register
+    return "Register"
+  }
+  *Net* {
+    # ^ Matches Net, Signed Net, Integer Net
+    return "Net"
+  }
+  *enum* {
+    # ^ Matches Verilog enum
+    return "Enum"
+  }
+  default {
+    return [string trim [string range $sig_description 1 [string wordend $sig_description 1]] " \n\r()\[\]{}"]
+  }
+}
 }
 
 proc get_net_array_length {signal_name} {

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -580,7 +580,7 @@ proc select_random_net {} {
 # flip a spefific bit of the given net name. returns [success, old_value, new_value] if the bit could be flipped
 proc flipbit {signal_name is_register} {
   # Get the current value in binary format e.g. "6'b101010" - this works both for enums and normal signals
-  set old_value_string [examine -radixenumnumeric -binary $signal_name]
+  set old_value_string [examine -radixenumnumeric -binary -showbase $signal_name]
 
   # Guard against strange signals that can not be read.
   if {$old_value_string == "<N/A>"} {
@@ -711,7 +711,7 @@ proc flipbit {signal_name is_register} {
 
 proc unflip_bit {signal_name select_index expected_value flip_signal_name unflip_value_binary} {
   # Get the current value in binary format e.g. "6'b101010" - this works both for enums and normal signals
-  set old_value_string [examine -radixenumnumeric -binary $signal_name]
+  set old_value_string [examine -radixenumnumeric -binary -showbase $signal_name]
 
   # Split it up into length and bits e.g. length="6", old_value_binary="101010"
   # We set defaults here for the rare case that we get an enum which is outside of the enumerated names

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -697,12 +697,13 @@ proc flipbit {signal_name is_register} {
 
   # Check that it actually changed and set success if it did
   set success [expr {[string equal $old_value_symbolic $new_value_symbolic]} ? 0 : 1] 
-  set was_bluetooth 0
 
   # Set up unflip
   if {[info exists unflip_time] && $success == 1} {
     set unflip_command "::unflip_bit $signal_name $select_index $flip_value_binary $flip_signal_name $unflip_value_binary"
     when -label unflip "\$now == @$unflip_time" "$unflip_command"
+  } else {
+    echo "[time_ns $::now]: \[Fault Injection\] Unflip on $signal_name not necessary."
   }
 
   set result [list $success $old_value_symbolic $new_value_symbolic]

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -697,7 +697,7 @@ proc unflip_bit {signal_name flip_signal_name flip_value_binary unflip_value_bin
 
   # If the signal is still in the flipped state, unflip it
   if {[string equal $flip_value_binary $current_value_binary]} {
-    force -deposit $flip_signal_name "2#$unflip_value_binary"
+    force -freeze $flip_signal_name "2#$unflip_value_binary" -cancel 0
 
     # Get the value back after the force command, also in the nice representation
     set new_value_string_out [examine -radixenumsymbolic $signal_name]

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -621,6 +621,17 @@ proc flipbit {signal_name is_register} {
     # And we expand the new_value_binary to have the same width as the old_value_binary, but the one bit flipped
     set flip_signal_name $signal_name
     set flip_value_binary [string replace $old_value_binary $flip_index_string $flip_index_string $new_bit]
+    
+    # Make sure the enum value is still reasonable, since questasim might run into problems otherwise
+    set enum_values 1
+    regexp {\[(\d+) enumeration values\]} $describe_string -> enum_values
+    set flip_value_decimal [expr {"0b$flip_value_binary"}]
+
+    if {$flip_value_decimal >= $enum_values} {
+      echo "WARNING: Enum injection out of bounds!"
+      return [list 0 "" ""]
+    }
+
     set unflip_value_binary $old_value_binary
     set select_index -1
   } else {

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -584,7 +584,7 @@ proc flipbit {signal_name is_register} {
 
   # Guard against strange signals that can not be read.
   if {$old_value_string == "<N/A>"} {
-    echo "WARNING: Found signal $signal_name which can not be read, returns $old_value_string instead!"
+    echo "\[Fault Injection\] Warning: Found signal $signal_name which can not be parsed, returns $old_value_string instead!"
     return [list 0 "" ""]
   }
 
@@ -628,7 +628,7 @@ proc flipbit {signal_name is_register} {
     set flip_value_decimal [expr {"0b$flip_value_binary"}]
 
     if {$flip_value_decimal >= $enum_values} {
-      echo "WARNING: Enum injection out of bounds!"
+      echo "\[Fault Injection\] Warning: Enum injection out of bounds!"
       return [list 0 "" ""]
     }
 

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -596,7 +596,7 @@ proc flipbit {signal_name is_register} {
     if {$is_register} {
       force -freeze $signal_name $new_value_numeric -cancel $::register_fault_duration
     } else {
-      force -freeze $signal_name $new_value_numeric, $old_value_numeric $::signal_fault_duration -cancel $::signal_fault_duration
+      force -freeze $signal_name $new_value_numeric -cancel $::signal_fault_duration
     }
     set success 1
   } else {
@@ -620,7 +620,7 @@ proc flipbit {signal_name is_register} {
     if {$is_register} {
       force -freeze $flip_signal_name $new_bit_value -cancel $::register_fault_duration
     } else {
-      force -freeze $flip_signal_name $new_bit_value, $old_bit_value $::signal_fault_duration -cancel $::signal_fault_duration
+      force -freeze $flip_signal_name $new_bit_value -cancel $::signal_fault_duration
     }
     if {[examine -radix binary $signal_name] != $bin_val} {set success 1}
   }

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -688,11 +688,9 @@ proc unflip_bit {signal_name flip_signal_name flip_value_binary unflip_value_bin
 
   # Split it up into length and bits e.g. length="6", old_value_binary="101010"
   # We set defaults here for the rare case that we get an enum which is outside of the enumerated names
-  # In that case, it might be that Questasim can't propperly output the binary representation and the regex fails
-  # We will then always flip the enum back into enum case 0 - for this it should always have an enumerated name.
-  set length 1
-  set current_value_binary "1"
-  regexp {(\d*)'b(\d*)} $current_value_string -> length current_value_binary
+  # In that case we assume the value did not change and we need to unflip it.
+  set current_value_binary $flip_value_binary
+  regexp {\d*'b(\d*)} $current_value_string -> current_value_binary
 
   # Get the current value in a nicer way just for the output
   set old_value_string_out [examine -radixenumsymbolic $signal_name]

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -650,7 +650,6 @@ proc flipbit {signal_name is_register} {
 
       set unflip_time [expr $::now + $::signal_fault_duration]
       set unflip_command "::unflip_bit $signal_name $flip_signal_name $flip_value_binary $unflip_value_binary"
-      when -label unflip "\$now == @$unflip_time" "$unflip_command"
     } else {
       # We don't need a manual unflip -> force directly with the wanted duration
       force -freeze $flip_signal_name "2#$flip_value_binary" -cancel $::signal_fault_duration
@@ -662,6 +661,12 @@ proc flipbit {signal_name is_register} {
 
   # Check that it actually changed and set success if it did
   set success [expr {[string equal $old_value_string_out $new_value_string_out]} ? 0 : 1] 
+
+  # Only set up unflip in case flip was sucessful
+  if {$success == 1 && [info exists unflip_time]} {
+    when -label unflip "\$now == @$unflip_time" "$unflip_command"
+  }
+
   set result [list $success $old_value_string_out $new_value_string_out]
   return $result
 }

--- a/scripts/inject_fault.tcl
+++ b/scripts/inject_fault.tcl
@@ -590,11 +590,6 @@ proc flipbit {signal_name is_register} {
   set old_value_binary "1"
   regexp {(\d*)'b(\d*)} $old_value_string -> length old_value_binary
 
-  # In case there are only Xs in the value we just give up and return no success.
-  if {[string length $old_value_binary] == 0} {
-    return [list 0 "" ""]
-  }
-
   # Decide which bit to flip e.g. we choose 3 out of 0 to 5
   set flip_index [expr int(rand()*$length)]
 
@@ -603,6 +598,11 @@ proc flipbit {signal_name is_register} {
   set flip_index_string [expr $length - $flip_index - 1]
   set old_bit [string index $old_value_binary $flip_index_string]
   set new_bit [expr {$old_bit == "1"} ? "0" : "1"]
+
+  # In case there are only Xs in the value we just give up and return no success.
+  if {[string length $old_bit] == 0} {
+    return [list 0 "" ""]
+  }
 
   # Get information about the signal. How it looks depends on the signal quite a bit
   set describe_string [describe $signal_name]

--- a/scripts/vulnerability_analysis.tcl
+++ b/scripts/vulnerability_analysis.tcl
@@ -81,6 +81,10 @@
 #                       If set to a negative number, this variable will be
 #                       changed to the execution time of the golden model plus
 #                       this negative number.
+# 'avoid_injection_time' : Time where no fault should be injected e.g. during 
+#                       clock transition. Set to 0 to disable.
+# 'avoid_injection_cycle' : Periodic repetition of times where to avoid injecting
+#                       e.g. clock cycle time. Set to 0 to disable.
 # ------------------------ Termination Monitor Signals ------------------------
 # 'correct_termination_signal' : Path to the testbench signal that indicates
 #                       a correct termination of the simulation. Note that an
@@ -219,6 +223,8 @@ if {![info exists ::max_num_tests]}           { set ::max_num_tests           1 
 if {![info exists ::internal_state]}          { set ::internal_state     [list] }
 if {![info exists ::earliest_injection_time]} { set ::earliest_injection_time 0 }
 if {![info exists ::latest_injection_time]}   { set ::latest_injection_time   0 }
+if {![info exists ::avoid_injection_time]}    { set ::avoid_injection_time    0 }
+if {![info exists ::avoid_injection_cycle]}   { set ::avoid_injection_cycle   0 }
 
 # Termination Monitor Signals
 if {![info exists ::correct_termination_signal] || \
@@ -369,10 +375,28 @@ proc injection_termination_report {id} {
 ###################
 
 proc get_random_injection_time {} {
-  set low $::earliest_injection_time
-  set high $::latest_injection_time
-  return [expr $low + int(rand() * ($high - $low))]
+    set low $::earliest_injection_time
+    set high $::latest_injection_time
+    
+    set avoid_time $::avoid_injection_time
+    set avoid_cycle $::avoid_injection_cycle
+
+    while {1} {
+        set random_time [expr $low + int(rand() * ($high - $low))]
+
+        # Retry if we happened to land on avoid time or avoid time cycle
+        if {$avoid_cycle > 0 && $avoid_time > 0 && ($random_time % $avoid_cycle) == $avoid_time} {
+            continue
+        }
+
+        if {$avoid_time > 0 && $random_time == $avoid_time} {
+            continue
+        }
+
+        return $random_time
+    }
 }
+
 
 proc wait_for_file {file_name {check_period_ms 2000}} {
   while {[catch {open $file_name r}]} {

--- a/scripts/vulnerability_analysis.tcl
+++ b/scripts/vulnerability_analysis.tcl
@@ -454,11 +454,11 @@ for {set i 0} { $i < [llength $::monitor_signal_list] } { incr i } {
 }
 
 # Create the log file
-set time_stamp [exec date +%Y%m%d_%H%M%S]
+set time_stamp [exec date +%Y%m%d_%H%M]
 if {$num_threads > 1} {
-  set filename "vulnerability_${time_stamp}_${::thread_id}.log"
+  set filename "vulnerability_${time_stamp}_${::thread_id}.csv"
 } else {
-  set filename "vulnerability_$time_stamp.log"
+  set filename "vulnerability_$time_stamp.csv"
 }
 set ::vulnerability_log [open $filename w+]
 puts $::vulnerability_log "seed,termination_cause,injection_time,termination_time,injected_net_name,monitors{${monitor_signals_names}}"


### PR DESCRIPTION
This PR fixes some of the problems which previously existed with the recovery of SETs / Single Event Transients / combinatorial faults.

The key insight from a few weeks of testing with these kind of faults is that signals in questasim can be of two different types which both have different behaviour:
- Reroverable Types
- Unrecoverable Types

This PR figures out what type of signal the fault should be injected to and treats it accordingly.

## Recoverable Types
Some signals that can recover from a `force -freeze` command on their own when it is cancelled e.g. will automatically be recalculated. With `describe` they have a type of `wire` or `net`. Additionally they do not seem to allow the use of `force -deposit`.

## Unrecoverable Types
Some signals can not recover on their own from a force command. With `describe` they have a type of `Register` / `Signed Register` or `Integer Register`.  They seem to allow the use of `force -deposit`.

As far as I have figured it out, all typical "registers" in harware are of the unrecoverable type, but also about two thirds of the signals one would typically think of as "combinatorial". A good example is the following combinatorial block, which ends up getting the type `register`:
```sv
always_comb begin
  some_signal = 1'b1;
end
```
It is clear why this circuitry is typically not recoverable - there is no input!

With these types of signals, simulating a SET means recovering them by a simulation event after some time. We currently do not know how to control simulation events precisely and as such can't do that.
As a workaround, this PR implements a check if an event happened e.g. the value changed after a force -deposit and only manually recovers if no event happened. 

The edge-case that the event wrote the same value as the SET can not be handled correctly at this point and will result in false-positives.

## Enums
For enumerated types it is currently not clear of what type they are as their `describe` does not say so. So far they seemed to behave like the unrecoverable type, and as such are treated like this. Enums have other problems as well, for example force commands on enums might overwrite other signals in the simulation. I call this "Bluetooth Fault Injection" and it needs to be treated seperately

## Extra Types
This PR is compatible with the `Signed` and `Integer` types which InjectaFault does not yet support. I think it makes sense having a independant discussion for adding support for those.