### PR TITLE
Fix get_net_reg_width width incorrect for registers indexed in reverse.

### DIFF
--- a/scripts/extract_nets.tcl
+++ b/scripts/extract_nets.tcl
@@ -58,8 +58,8 @@ proc get_net_array_length {signal_name} {
 proc get_net_reg_width {signal_name} {
   set sig_description [examine -describe $signal_name]
   set length 1
-  if {[regexp "\\\[(\\d+):(\\d+)\\\]" $sig_description -> up_lim low_lim]} {
-    set length [expr $up_lim - $low_lim + 1]
+  if {[regexp "\\\[(\\d+):(\\d+)\\\]" $sig_description -> lim_a lim_b]} {
+    set length [expr {abs($lim_a - $lim_b) + 1}]
   }
   return $length
 }


### PR DESCRIPTION
@Xeratec and I were looking at the bit widths of the signals extracted with InjectaFault on RedMulE and found some signals with width 0 or -1 which didn't make any sense.

Upon further investigation we found out that the describe command would return signals as either [0:n] or [n:0], depending on which way around it is defined in SystemVerilog. However the get_net_reg_width function would only calculate correctly in case describe returns the signal as [0:n].

This PR makes the get_net_reg_width agnostic to which way describe returns the signal.

Here a quick test with the old and new behavior:
![image](https://github.com/user-attachments/assets/3568e410-dc3b-4d7c-9410-128c9e4084ef)
